### PR TITLE
Preliminary support for IE via Google Chrome Frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,10 @@
 <html>
 <head>
 <meta name="google-site-verification" content="772SnMSyIMzcGQJ_74cYZEQB2CZKswi0L0cvhWhV4cc" />
+<!--
+    Use Google Chrome Frame to render in IE if available.
+-->
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
 <link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>


### PR DESCRIPTION
The only change here is to add a meta tag that will use [Google Chrome Frame](https://developers.google.com/chrome/chrome-frame/) as the rendering engine in Internet Explorer when it has already been installed. I did not include the JavaScript necessary to install GCF when missing because that would require lengthy discussion about ImageJS internals first. This change only affects IE -- it is ignored by other web browsers.
