### PR TITLE
Allow single file parameter to readImage

### DIFF
--- a/imagejs.js
+++ b/imagejs.js
@@ -16,7 +16,15 @@ canvas2Image:function(canvasid, callback){
 },
 
 readImage:function(f){ // read image file
-	f=f.item(0); // assuming there is only one file
+	let obj = f.item;
+	if (typeof obj !== 'undefined' && typeof obj === 'function') {
+		// safe to use the function
+		f = f.item(0);
+	}
+	else {
+		// default to f
+	}
+	console.log('hello from imagejs. file is', f);
 	jmat.gId('msg').textContent='loading '+f.name+' ... ';
 	imagejs.data.fname=f.name;
 	reader = new FileReader();


### PR DESCRIPTION
`readImage` takes a `FileList` object as a parameter, and extracts the one file from it.  I propose to check to make sure we get an `f.item` property back.  If _not_, then assume we have passed in one file.  Current assumption being there is only one file in the FileList that was passed.