### PR TITLE
Fix error "invalid assignment"

### DIFF
--- a/imagejs.js
+++ b/imagejs.js
@@ -101,7 +101,15 @@ menu:function(x,id){
 	// process a menu structure
 	var f = jmat.fieldnames(x);
 	if(!jmat.gId('menu '+id)){var sel = jmat.cEl('select','menu '+id)} // create if it doesn't exist
-	else{jmat.gId('menu '+id)=jmat.gId('menu '+id).splice(0,0)} // else clear SELECT options
+	else{
+		//jmat.gId('menu '+id)=jmat.gId('menu '+id).splice(0,0)
+		// else clear SELECT options
+		var sel = jmat.gId('menu ' + id);
+		var i;
+		for (i = sel.options.length - 1; i >= 0; i--) {
+			sel.remove(i);
+		}
+	} 
 	//jmat.gId('menu').appendChild(sel);
 	var opt = jmat.cEl('option','option '+id);opt.textContent=id; // menu name at the top
 	sel.appendChild(opt);


### PR DESCRIPTION
Patch is to fix error.

The error is `invalid assignment left-hand side`.  But it originates because it cannot `splice()` the object on the right-hand side (it's not an array).
 
Since the objective is to clear the select options (the options get loaded in subsequent code), I added code to clear the options.

_FYI &ndash; Steps to create error: 1) load image 2) select 'chromomarkers' from menu.  3) click 'Main Menu' and then 'Load' 4) select 'Count Shapes'_

